### PR TITLE
Fixed for 64bits (at least for decompression)

### DIFF
--- a/MeltWSF.cpp
+++ b/MeltWSF.cpp
@@ -104,14 +104,14 @@ int stricmp( const char *s1, const char *s2 )
 
 int MakeMelt( int argc, char **argv )
 {
-	long nFiles;
-	long x;
+	int nFiles;
+	int x;
 	CWSFMod wMod;
 	CWSFPack *wP;
 	wsfb *bPack;
 	wsul nPack;
 
-	long i;
+	int i;
 	
 	int compile = 0;
 	

--- a/MiniWSF.cpp
+++ b/MiniWSF.cpp
@@ -133,8 +133,8 @@ int GetSaveName(HWND hWnd, char *szF, char *Filter, int numfil, char *defext)
 
 int BuildMake( HWND h, char *cTitle, char *cMessage )
 {
-	long nFiles;
-	long x;
+	int nFiles;
+	int x;
 	char cOut[4500];
 	char OutFile[MAX_PATH];
 	OPENFILENAME opf;

--- a/WGMPickDlg.h
+++ b/WGMPickDlg.h
@@ -26,7 +26,7 @@
 /// \file WGMPickDlg.h
 /// WGM Selection Dialog Header
 
-#include <windows.h>
+//#include <windows.h>
 #include "WSFGlob.h"
 
 typedef enum

--- a/WSFComp.c
+++ b/WSFComp.c
@@ -23,11 +23,11 @@
 
 typedef unsigned char byte;
 typedef unsigned short word;
-typedef unsigned long dword;
+typedef unsigned int dword;
 
 byte *g_b;
-unsigned long g_p;
-unsigned long g_s;
+unsigned int g_p;
+unsigned int g_s;
 
 #define BYTE byte
 
@@ -51,7 +51,7 @@ int getiw (void)
 
 static int readblock(void)
 {
-	long size;
+	int size;
 
 	size = getiw();
 	if (size < 0)
@@ -106,7 +106,7 @@ static int readbits(int bitwidth)
 /** WARNING - do we even need to pass `right`? */
 /** WARNING - why bother memsetting at all? The whole array is written... */
 /** WARNING - check for endianness safety */
-unsigned long wsf_decompress8(unsigned char *f, signed char *left, signed char *right, int len, int cmwt)
+unsigned int wsf_decompress8(unsigned char *f, signed char *left, signed char *right, int len, int cmwt)
 {
 	int blocklen, blockpos;
 	byte bitwidth;
@@ -198,11 +198,11 @@ unsigned long wsf_decompress8(unsigned char *f, signed char *left, signed char *
 }
 
 
-unsigned long wsf_decompress16(unsigned char *f, signed char *left, signed char *right, int len, int cmwt)
+unsigned int wsf_decompress16(unsigned char *f, signed char *left, signed char *right, int len, int cmwt)
 {
 	int blocklen, blockpos;
 	byte bitwidth;
-	long val;
+	int val;
 	short d1, d2;
 
 	g_b = f;
@@ -288,7 +288,7 @@ unsigned long wsf_decompress16(unsigned char *f, signed char *left, signed char 
 	return g_b-f;
 }
 
-unsigned long ITReadBits(unsigned long *bitbuf, unsigned int *bitnum, byte *ibuf, char n)
+unsigned int ITReadBits(unsigned int *bitbuf, unsigned int *bitnum, byte *ibuf, char n)
 //-----------------------------------------------------------------
 {
 	dword retval = 0;
@@ -315,22 +315,22 @@ unsigned long ITReadBits(unsigned long *bitbuf, unsigned int *bitnum, byte *ibuf
 }
 
 #define IT215_SUPPORT
-unsigned long wsfITUnpack8Bit(char *pSample, unsigned long dwLen, byte * lpMemFile, unsigned long dwMemLength, int b215)
+unsigned int wsfITUnpack8Bit(char *pSample, unsigned int dwLen, byte * lpMemFile, unsigned int dwMemLength, int b215)
 //-------------------------------------------------------------------------------------------
 {
 	char *pDst = pSample;
 	byte *pSrc = lpMemFile;
-	unsigned long wHdr = 0;
-	unsigned long wCount = 0;
-	unsigned long bitbuf = 0;
+	unsigned int wHdr = 0;
+	unsigned int wCount = 0;
+	unsigned int bitbuf = 0;
 	unsigned int bitnum = 0;
 	BYTE bLeft = 0, bTemp = 0, bTemp2 = 0;
 
 	memset(pSample,0,dwLen);
 	while (dwLen)
 	{
-		unsigned long dwPos;
-		unsigned long d;
+		unsigned int dwPos;
+		unsigned int d;
 		if (!wCount)
 		{
 			wCount = 0x8000;
@@ -349,8 +349,8 @@ unsigned long wsfITUnpack8Bit(char *pSample, unsigned long dwLen, byte * lpMemFi
 			word wBits = (word)ITReadBits(&bitbuf, &bitnum, pSrc, bLeft);
 			if (bLeft < 7)
 			{
-				unsigned long i = 1 << (bLeft-1);
-				unsigned long j = wBits & 0xFFFF;
+				unsigned int i = 1 << (bLeft-1);
+				unsigned int j = wBits & 0xFFFF;
 				if (i != j) goto UnpackByte;
 				wBits = (word)(ITReadBits(&bitbuf, &bitnum, pSrc, 3) + 1) & 0xFF;
 				bLeft = ((BYTE)wBits < bLeft) ? (BYTE)wBits : (BYTE)((wBits+1) & 0xFF);
@@ -402,22 +402,22 @@ unsigned long wsfITUnpack8Bit(char *pSample, unsigned long dwLen, byte * lpMemFi
 }
 
 
-unsigned long wsfITUnpack16Bit(char *pSample, unsigned long dwLen, byte *lpMemFile, unsigned long dwMemLength, int b215)
+unsigned int wsfITUnpack16Bit(char *pSample, unsigned int dwLen, byte *lpMemFile, unsigned int dwMemLength, int b215)
 //--------------------------------------------------------------------------------------------
 {
 	signed short *pDst = (signed short *)pSample;
 	byte *pSrc = lpMemFile;
-	unsigned long wHdr = 0;
-	unsigned long wCount = 0;
-	unsigned long bitbuf = 0;
+	unsigned int wHdr = 0;
+	unsigned int wCount = 0;
+	unsigned int bitbuf = 0;
 	unsigned int bitnum = 0;
 	BYTE bLeft = 0;
 	signed short wTemp = 0, wTemp2 = 0;
 
 	while (dwLen)
 	{
-		unsigned long d;
-		unsigned long dwPos;
+		unsigned int d;
+		unsigned int dwPos;
 		if (!wCount)
 		{
 			wCount = 0x4000;
@@ -433,11 +433,11 @@ unsigned long wsfITUnpack16Bit(char *pSample, unsigned long dwLen, byte *lpMemFi
 		dwPos = 0;
 		do
 		{
-			unsigned long dwBits = ITReadBits(&bitbuf, &bitnum, pSrc, bLeft);
+			unsigned int dwBits = ITReadBits(&bitbuf, &bitnum, pSrc, bLeft);
 			if (bLeft < 7)
 			{
-				unsigned long i = 1 << (bLeft-1);
-				unsigned long j = dwBits;
+				unsigned int i = 1 << (bLeft-1);
+				unsigned int j = dwBits;
 				if (i != j) goto UnpackByte;
 				dwBits = ITReadBits(&bitbuf, &bitnum, pSrc, 4) + 1;
 				bLeft = ((BYTE)(dwBits & 0xFF) < bLeft) ? (BYTE)(dwBits & 0xFF) : (BYTE)((dwBits+1) & 0xFF);
@@ -445,8 +445,8 @@ unsigned long wsfITUnpack16Bit(char *pSample, unsigned long dwLen, byte *lpMemFi
 			}
 			if (bLeft < 17)
 			{
-				unsigned long i = (0xFFFF >> (17 - bLeft)) + 8;
-				unsigned long j = (i - 16) & 0xFFFF;
+				unsigned int i = (0xFFFF >> (17 - bLeft)) + 8;
+				unsigned int j = (i - 16) & 0xFFFF;
 				if ((dwBits <= j) || (dwBits > (i & 0xFFFF))) goto UnpackByte;
 				dwBits -= j;
 				bLeft = ((BYTE)(dwBits & 0xFF) < bLeft) ? (BYTE)(dwBits & 0xFF) : (BYTE)((dwBits+1) & 0xFF);
@@ -464,7 +464,7 @@ unsigned long wsfITUnpack16Bit(char *pSample, unsigned long dwLen, byte *lpMemFi
 				BYTE shift = 16 - bLeft;
 				signed short c = (signed short)(dwBits << shift);
 				c >>= shift;
-				dwBits = (unsigned long)c;
+				dwBits = (unsigned int)c;
 			}
 			dwBits += wTemp;
 			wTemp = (signed short)dwBits;
@@ -2949,7 +2949,7 @@ static lzo_byte _wrkmem [ LZO1X_MEM_COMPRESS + 16 ];
 // 
 //***************************************************************************** */
 
-int DoCompression( unsigned char *bInput, long nFileSize, long nOldSize, unsigned char **bOutput, unsigned long *nOutLen, char bCompress )
+int DoCompression( unsigned char *bInput, int nFileSize, int nOldSize, unsigned char **bOutput, unsigned int *nOutLen, char bCompress )
 {
 	int r;
 	lzo_uint in_len;

--- a/WSFComp.h
+++ b/WSFComp.h
@@ -32,14 +32,14 @@ extern "C" {
 /// @param bOutput Replaced with pointer to data (must be freed)
 /// @param nOutLen Replaced with output size
 /// @param bCompress TRUE = Compress, FALSE = Decompress
-int DoCompression( unsigned char *bInput, long nFileSize, long nOldSize, unsigned char **bOutput, unsigned long *nOutLen, char bCompress );
+int DoCompression( unsigned char *bInput, int nFileSize, int nOldSize, unsigned char **bOutput, unsigned int *nOutLen, char bCompress );
 
 // Uses dumb here :/
-unsigned long wsf_decompress16(unsigned char *f, signed char *left, signed char *right, int len, int cmwt);
-unsigned long wsf_decompress8(unsigned char *f, signed char *left, signed char *right, int len, int cmwt);
+unsigned int wsf_decompress16(unsigned char *f, signed char *left, signed char *right, int len, int cmwt);
+unsigned int wsf_decompress8(unsigned char *f, signed char *left, signed char *right, int len, int cmwt);
 // MODPLUG STYLE
-unsigned long wsfITUnpack16Bit(char *pSample, unsigned long dwLen, unsigned char *lpMemFile, unsigned long dwMemLength, int b215);
-unsigned long wsfITUnpack8Bit(char *pSample, unsigned long dwLen, unsigned char *lpMemFile, unsigned long dwMemLength, int b215);
+unsigned int wsfITUnpack16Bit(char *pSample, unsigned int dwLen, unsigned char *lpMemFile, unsigned int dwMemLength, int b215);
+unsigned int wsfITUnpack8Bit(char *pSample, unsigned int dwLen, unsigned char *lpMemFile, unsigned int dwMemLength, int b215);
 
 
 #ifdef __cplusplus

--- a/WSFGlob.h
+++ b/WSFGlob.h
@@ -53,12 +53,12 @@ typedef unsigned char wsfb;
 typedef unsigned short wsus;
 
 /// Unsigned Long Typedef
-typedef unsigned long wsul;
+typedef unsigned int wsul;
 
 /// Sample Output for use with CWSFPack::GetSamp
 typedef struct wsf_sampout_s
 {
-	unsigned long nSize;	///< Size of sample
+	unsigned int nSize;	///< Size of sample
 	wsfb *bSampData;		///< Sample Data
 
 	wsus nCh;			///< Number of Channels
@@ -126,7 +126,7 @@ wsul wsfwrite( void *bData, wsul nSize, wsf_file *wf );
 wsul wsfread( void *bData, wsul nSize, wsf_file *wf );
 void wsfseek( wsul nPos, wsf_file *wf );
 void wsfbegin( wsul nOff, wsf_file *wf );
-void wsfend( long nOff, wsf_file *wf );
+void wsfend( int nOff, wsf_file *wf );
 
 void wsfclose( wsf_file *wf );
 

--- a/WSFLoadersV1.cpp
+++ b/WSFLoadersV1.cpp
@@ -82,21 +82,21 @@ int CWSFLoaderV1::Save( wsf_modout *wOut, wsf_loaddata *wLD )
 // 
 //***************************************************************************** */
 
-int CWSFLoaderV1::Save( wsf_modout *wOut, wsf_loaddata *wLD, long *nSCounts )
+int CWSFLoaderV1::Save( wsf_modout *wOut, wsf_loaddata *wLD, int *nSCounts )
 {
-	unsigned long i;
+	unsigned int i;
 	wsfb bHi,bLo;
 	wsfb *bDat;
-	unsigned long nSize;
+	unsigned int nSize;
 	wsfb bFill[4];
 	unsigned short sH;
-	unsigned long nCSize;
+	unsigned int nCSize;
 	CBaseLoader *xBL;
 	wsfb *bCDat;
-	long nSub;
+	int nSub;
 	wsf_gspdata gD;
 	char cOutExt[5];
-	long nSCount[WSFS_COUNT];
+	int nSCount[WSFS_COUNT];
 
 	wsul *nPar;
 	wsfb *bFlag;
@@ -194,13 +194,13 @@ int CWSFLoaderV1::Save( wsf_modout *wOut, wsf_loaddata *wLD, long *nSCounts )
 #endif
 
 	// Write Mod FULL Size
-	MAPP(&nSize,1,sizeof(unsigned long));
+	MAPP(&nSize,1,4);
 
 	// Compress MOD
 	DoCompression(bDat,nSize,0,&bCDat,&nCSize,true);
 
 	// Write Mod Compressed Size
-	MAPP(&nCSize,1,sizeof(unsigned long));
+	MAPP(&nCSize,1,4);
 
 	// Write (Compressed) Mod
 	MAPP(bCDat,1,nCSize);
@@ -209,7 +209,7 @@ int CWSFLoaderV1::Save( wsf_modout *wOut, wsf_loaddata *wLD, long *nSCounts )
 	free(bCDat);
 
 	// Write number of Samples
-	MAPP(&wLD->nSamples,1,sizeof(unsigned long));
+	MAPP(&wLD->nSamples,1,4);
 
 	nIDx = (wsul*)malloc(sizeof(wsul)*wLD->nSamples);
 	nPar = (wsul*)malloc(sizeof(wsul)*wLD->nSamples);
@@ -225,8 +225,8 @@ int CWSFLoaderV1::Save( wsf_modout *wOut, wsf_loaddata *wLD, long *nSCounts )
 	{
 		wsf_sample *wS;
 		wsf_sampout wO;
-		unsigned long *nS;
-		unsigned long nID;
+		unsigned int *nS;
+		unsigned int nID;
 		char cSampSig[SIGNATURESIZE+1];
 
 		// Pick Sample
@@ -320,19 +320,19 @@ int CWSFLoaderV1::Save( wsf_modout *wOut, wsf_loaddata *wLD, long *nSCounts )
 	free(bExtras);
 
 	// Write Sub Diff
-	MAPP(&nSub,1,sizeof(unsigned long));
+	MAPP(&nSub,1,4);
 
 	for (i=0;i<wLD->nSamples;i++)
 	{
-		unsigned long *nS;
+		unsigned int *nS;
 
 		// Pick Sample
 		nS = &wLD->nSampleSizes[i];
 
 		// Write Sample Signature
-		MAPP(&nIDx[i],1,sizeof(unsigned long));
+		MAPP(&nIDx[i],1,4);
 		// Write Sample Size
-		MAPP(nS,1,sizeof(unsigned long));
+		MAPP(nS,1,4);
 		// Write Sample Offset!
 		MAPP(&gD.nSampOffs[i],1,sizeof(wsul));
 
@@ -356,7 +356,7 @@ int CWSFLoaderV1::Save( wsf_modout *wOut, wsf_loaddata *wLD, long *nSCounts )
 	MRESET(&wOut->bModData,&wOut->nSize);
 
 	if (nSCounts)
-		memcpy(nSCounts,&nSCount,sizeof(long)*(WSFS_COUNT));
+		memcpy(nSCounts,&nSCount,4*(WSFS_COUNT));
 
 	return 0;
 }
@@ -386,8 +386,8 @@ int CWSFLoaderV1::Load( wsfb *bData, wsul nSize, wsf_loaddata *wLD )
 	char cHead[4];
 	char cTPack[27];
 	char cPack[200];
-	unsigned long i;
-	unsigned long nCSize;
+	unsigned int i;
+	unsigned int nCSize;
 	wsfb *bCDat;
 	wsul *nIDs;
 	wsfb *bFlags;
@@ -430,8 +430,8 @@ int CWSFLoaderV1::Load( wsfb *bData, wsul nSize, wsf_loaddata *wLD )
 	wLD->nModType = m_nModType;
 
 	// Read size of mod file ahead and then read the mod
-	MREAD(&wLD->nModSize,1,sizeof(unsigned long));		// Full Size
-	MREAD(&nCSize,1,sizeof(unsigned long));		// Compressed Size
+	MREAD(&wLD->nModSize,1,4);		// Full Size
+	MREAD(&nCSize,1,4);		// Compressed Size
 
 	// Allocate Room 
 	bCDat = (wsfb*)malloc(nCSize);
@@ -444,9 +444,9 @@ int CWSFLoaderV1::Load( wsfb *bData, wsul nSize, wsf_loaddata *wLD )
 	free(bCDat);
 
 	// After the mod is read, find samples
-	MREAD(&wLD->nSamples,1,sizeof(unsigned long));
+	MREAD(&wLD->nSamples,1,4);
 	wLD->bSamples = (wsf_sample*)malloc(sizeof(wsf_sample)*wLD->nSamples);
-	wLD->nSampleSizes = (unsigned long*)malloc(sizeof(unsigned long)*wLD->nSamples);
+	wLD->nSampleSizes = (unsigned int*)malloc(4*wLD->nSamples);
 	wLD->nSampleOffsets = (wsul*)malloc(sizeof(wsul)*wLD->nSamples);
 
 	// Read Extras
@@ -465,9 +465,9 @@ int CWSFLoaderV1::Load( wsfb *bData, wsul nSize, wsf_loaddata *wLD )
 		nExtras=0;
 		bExtras = (wsul*)malloc(0);
 	}
-		
 
-	MREAD(&wLD->nSubDiff,1,sizeof(unsigned long));
+
+	MREAD(&wLD->nSubDiff,1,4);
 
 	// Make array for number of IDs
 	nIDs = (wsul*)malloc(sizeof(wsul)*(wLD->nSamples+nExtras));
@@ -485,7 +485,7 @@ int CWSFLoaderV1::Load( wsfb *bData, wsul nSize, wsf_loaddata *wLD )
 		nID = &nIDs[i];
 
 		MREAD(nID,1,sizeof(wsul));
-		MREAD(nS,1,sizeof(unsigned long));
+		MREAD(nS,1,4);
 		
 		if (TESTVER(1,12))
 		{

--- a/WSFMod.cpp
+++ b/WSFMod.cpp
@@ -407,7 +407,7 @@ int nTest=0;
 // [nRepOff] : Replaces data at this offset
 // [nRepLength] : with this length
 // [*bFill] : with data at this buffer
-// [nFillLen] : that is this long
+// [nFillLen] : that is this int
 // and
 // Returns:	the new buffer
 // 
@@ -418,11 +418,11 @@ int nTest=0;
 /// This is used when the samples are inserted into the mod from the sample library,
 /// or vice versa when the samples are extracted from the sample library.
 /// \note The bIn parameter is not automatically freed and it needs to be.
-wsfb *CBaseLoader::ReplaceData( wsfb *bIn, unsigned long nIn, unsigned long *nOut, unsigned long nRepOff, unsigned long nRepLength, wsfb *bFill, unsigned long nFillLen )
+wsfb *CBaseLoader::ReplaceData( wsfb *bIn, unsigned int nIn, unsigned int *nOut, unsigned int nRepOff, unsigned int nRepLength, wsfb *bFill, unsigned int nFillLen )
 {
 	wsfb *bOut;
 	wsfb *bPos;
-	unsigned long nNewSize;
+	unsigned int nNewSize;
 	
 	// Gets new size
 	nNewSize = nIn - nRepLength + nFillLen;
@@ -544,7 +544,7 @@ int CWSFMod::ReplaceSamplesForSave( wsf_modout *wOut, CBaseLoader *xBL, wsf_load
 	wsfb *bDat;
 	wsul i;
 	wsul *nOffs;
-	long nSub;
+	int nSub;
 
 	// Copy over MOD Data
 	nSize = wLD->nModSize;
@@ -623,7 +623,7 @@ int CWSFMod::ReplaceSamplesForSave( wsf_modout *wOut, CBaseLoader *xBL, wsf_load
 // 
 //***************************************************************************** */
 
-int CWSFMod::WriteMod( wsf_modout *wOut, int nWSF, long *nSCounts )
+int CWSFMod::WriteMod( wsf_modout *wOut, int nWSF, int *nSCounts )
 {
 	int nr;
 	CBaseLoader *xBL;
@@ -816,7 +816,7 @@ void CWSFMod::SetPassSum( int nPassSum )
 
 int CWSFMod::FreeMod( void )
 {
-	unsigned long i;
+	unsigned int i;
 	if (!m_nLoaded)
 		return 1;
 
@@ -1317,7 +1317,7 @@ int CWSFAscii::SetWSFAscii( char *fn, char *cIn )
 	wsf_file *MFile;
 	unsigned short nS;
 	wsfb *bDat;
-	unsigned long nSize;
+	unsigned int nSize;
 	
 	// Open the file
 	MFile = wsfopenfile(fn);
@@ -2289,7 +2289,7 @@ void wsfbegin( wsul nOff, wsf_file *wf )
 /// \param *wf file handle
 //////////////////////////////////////////////////////
 
-void wsfend( long nOff, wsf_file *wf )
+void wsfend( int nOff, wsf_file *wf )
 {
 	wf->nPos = wf->nSize + nOff;
 

--- a/WSFMod.h
+++ b/WSFMod.h
@@ -86,14 +86,14 @@ extern wsfb g_bModFlag[];
 typedef struct wsf_modout_s
 {
 	/// Size of bModData
-	unsigned long nSize;
+	unsigned int nSize;
 
 	/// Mod Buffer
 	wsfb *bModData;
 
 } wsf_modout;
 
-wsfb *ReplaceData( wsfb *bIn, unsigned long nIn, unsigned long *nOut, unsigned long nRepOff, unsigned long nRepLength, wsfb *bFill, unsigned long nFillLen );
+wsfb *ReplaceData( wsfb *bIn, unsigned int nIn, unsigned int *nOut, unsigned int nRepOff, unsigned int nRepLength, wsfb *bFill, unsigned int nFillLen );
 
 #ifndef WSFNOASCII
 
@@ -296,12 +296,12 @@ class CBaseLoader
 
 	/// This function is called by CWSFMod to restore the original samples.
 
-		wsfb *ReplaceData( wsfb *bIn, unsigned long nIn, unsigned long *nOut, unsigned long nRepOff, unsigned long nRepLength, wsfb *bFill, unsigned long nFillLen );
+		wsfb *ReplaceData( wsfb *bIn, unsigned int nIn, unsigned int *nOut, unsigned int nRepOff, unsigned int nRepLength, wsfb *bFill, unsigned int nFillLen );
 
 	wsfb	*g_bS;	///< Byte Start	(used for memorymacros MXXX)
 	wsfb	*g_bP;	///< Byte Pos (used for memorymacros MXXX)
-	unsigned long g_nB;	///< Size of bytes (used for memorymacros MXXX)
-	unsigned long g_nW; ///< Byte Written (used for memorymacros MXXX)
+	unsigned int g_nB;	///< Size of bytes (used for memorymacros MXXX)
+	unsigned int g_nW; ///< Byte Written (used for memorymacros MXXX)
 
 	wsf_sample *m_wCopySamps;	///< 'Carbon Copy' of sample data for AllowSampleEdit
 
@@ -436,10 +436,10 @@ class CWSFLoader : public CBaseLoader
 		int Save( wsf_modout *wOut, wsf_loaddata *wLD );
 
 	/// Additional Saving Unit
-		int Save( wsf_modout *wOut, wsf_loaddata *wLD, long *nSCounts );
+		int Save( wsf_modout *wOut, wsf_loaddata *wLD, int *nSCounts );
 
 	/// Saving V1.x Mods
-		int SaveVer1( wsf_modout *wOut, wsf_loaddata *wLD, long *nSCounts );
+		int SaveVer1( wsf_modout *wOut, wsf_loaddata *wLD, int *nSCounts );
 
 	/// Function to get pointers to ACTUAL samples
 //	int GetSamplePointers( wsfb *bData, wsul nSize, wsf_gspdata *gspData );
@@ -516,7 +516,7 @@ class CWSFMod
 	/// Write Mod.
 	/// Write's Mod
 	/// \param nWSF nonzero if saving to WSF file
-		int WriteMod( wsf_modout *wOut, int nWSF, long *nSCounts = NULL );
+		int WriteMod( wsf_modout *wOut, int nWSF, int *nSCounts = NULL );
 
 #ifndef WSFNOSAVE
 

--- a/WSFModV1.cpp
+++ b/WSFModV1.cpp
@@ -283,7 +283,7 @@ int CWSFModV1::ReplaceSamplesForSave( wsf_modout *wOut, CBaseLoader *xBL, wsf_lo
 	wsfb *bDat;
 	wsul i;
 	wsul *nOffs;
-	long nSub;
+	int nSub;
 
 	// Copy over MOD Data
 	nSize = wLD->nModSize;
@@ -350,7 +350,7 @@ int CWSFModV1::ReplaceSamplesForSave( wsf_modout *wOut, CBaseLoader *xBL, wsf_lo
 // 
 //***************************************************************************** */
 
-int CWSFModV1::WriteMod( wsf_modout *wOut, int nWSF, long *nSCounts )
+int CWSFModV1::WriteMod( wsf_modout *wOut, int nWSF, int *nSCounts )
 {
 	int nr;
 	CBaseLoader *xBL;
@@ -528,7 +528,7 @@ void CWSFModV1::SetPassSum( int nPassSum )
 
 int CWSFModV1::FreeMod( void )
 {
-	unsigned long i;
+	unsigned int i;
 	if (!m_nLoaded)
 		return 1;
 

--- a/WSFModV1.h
+++ b/WSFModV1.h
@@ -83,7 +83,7 @@ extern char *g_cModDesc[];
 /// These are flags to show whether or not the format is supported or not
 extern wsfb g_bModFlag[];
 
-wsfb *ReplaceData( wsfb *bIn, unsigned long nIn, unsigned long *nOut, unsigned long nRepOff, unsigned long nRepLength, wsfb *bFill, unsigned long nFillLen );
+wsfb *ReplaceData( wsfb *bIn, unsigned int nIn, unsigned int *nOut, unsigned int nRepOff, unsigned int nRepLength, wsfb *bFill, unsigned int nFillLen );
 
 /// Preserves ModFusion v1 WSF format!
 /// Handles Loading + Saving WSF modules.
@@ -102,7 +102,7 @@ public:
 	int Save( wsf_modout *wOut, wsf_loaddata *wLD );
 
 	// Additional Saving Unit
-	int Save( wsf_modout *wOut, wsf_loaddata *wLD, long *nSCounts );
+	int Save( wsf_modout *wOut, wsf_loaddata *wLD, int *nSCounts );
 
 	/// Function to get pointers to ACTUAL samples
 //	int GetSamplePointers( wsfb *bData, wsul nSize, wsf_gspdata *gspData );
@@ -162,7 +162,7 @@ public:
 	int FreeMod( void );
 
 	/// Write Mod
-	int WriteMod( wsf_modout *wOut, int nWSF, long *nSCounts = NULL );
+	int WriteMod( wsf_modout *wOut, int nWSF, int *nSCounts = NULL );
 
 	/// Save Pack
 	int SavePack( int nComp );

--- a/WSFOgg.cpp
+++ b/WSFOgg.cpp
@@ -192,8 +192,8 @@ int OggEncode( wsul nSize, wsfb *bData, wsul nCh, int nBit, wsf_file *wOut, wsul
   }
   
   while(!eos){
-    long i;
-    long bytes=wsfread(readbuffer,nRLen*4,wIn); /* stereo hardwired here */
+    int i;
+    int bytes=wsfread(readbuffer,nRLen*4,wIn); /* stereo hardwired here */
 
     if(bytes==0){
       /* end of file.  this can be done implicitly in the mainline,

--- a/WSFPack.cpp
+++ b/WSFPack.cpp
@@ -81,8 +81,8 @@ extern CStatusDlg *g_mStatus;
 
 wsfb	*gp_bS;	// Byte Start
 wsfb	*gp_bP;	// Byte Pos
-unsigned long gp_nB;	// Size of bytes
-unsigned long gp_nW;
+unsigned int gp_nB;	// Size of bytes
+unsigned int gp_nW;
 
 #define POPEN(x,y)		{ gp_bS = x; gp_bP = gp_bS; gp_nB = y; gp_nW = 0; }
 #define PREAD(x,y,z)	{ memcpy(x,gp_bP,y*z); gp_bP+=y*z; }
@@ -96,8 +96,8 @@ unsigned long gp_nW;
 
 wsfb	*gm_bS;	// Byte Start
 wsfb	*gm_bP;	// Byte Pos
-unsigned long gm_nB;	// Size of bytes
-unsigned long gm_nW;
+unsigned int gm_nB;	// Size of bytes
+unsigned int gm_nW;
 
 #define MOPEN(x,y)		{ gm_bS = x; gm_bP = gm_bS; gm_nB = y; gm_nW = 0; }
 #define MREAD(x,y,z)	{ memcpy(x,gm_bP,y*z); gm_bP+=y*z; }
@@ -353,7 +353,7 @@ CWSFPack::~CWSFPack()
 // 
 //***************************************************************************** */
 
-int CWSFPack::DeCompressSample( wsfb *bCompSamp, unsigned long nCompSize, wsfb **bOutSamp, unsigned long nFullSize )
+int CWSFPack::DeCompressSample( wsfb *bCompSamp, unsigned int nCompSize, wsfb **bOutSamp, unsigned int nFullSize )
 {
 	return DoCompression(bCompSamp,nCompSize,nFullSize,bOutSamp,NULL,false);
 }
@@ -488,7 +488,7 @@ int CWSFPack::LoadPackV2( wsf_file *PFile, wsul *nIDs, wsul nNumIDs, int nNoBulk
 				// Uncompressed sampledata
 
 				// Read Sample Size
-				wsfread(&wSamp->nSize,sizeof(unsigned long),PFile);
+				wsfread(&wSamp->nSize,4,PFile);
 				wSamp->nRawSize = wSamp->nSize;
 				wSamp->nStoredSize = wSamp->nSize;
 
@@ -515,12 +515,12 @@ int CWSFPack::LoadPackV2( wsf_file *PFile, wsul *nIDs, wsul nNumIDs, int nNoBulk
 			else
 			{
 				// Compressed Sampledata ;_;
-				unsigned long nFullSize;	// Full Size
-				unsigned long nCompSize;	// Size when Compressed
+				unsigned int nFullSize;	// Full Size
+				unsigned int nCompSize;	// Size when Compressed
 				wsfb *bCompData;			// Compressed DAta
 
 				// Sample Size
-				wsfread(&nCompSize,sizeof(unsigned long),PFile);
+				wsfread(&nCompSize,4,PFile);
 				wSamp->nStoredSize = nCompSize;
 
 				if (nF)
@@ -530,7 +530,7 @@ int CWSFPack::LoadPackV2( wsf_file *PFile, wsul *nIDs, wsul nNumIDs, int nNoBulk
 					wsfread(bCompData,nCompSize,PFile);
 
 					// Sample UnComp Size
-					wsfread(&nFullSize,sizeof(unsigned long),PFile);
+					wsfread(&nFullSize,4,PFile);
 					wSamp->nSize = nFullSize;
 					wSamp->nRawSize = nFullSize;
 
@@ -645,7 +645,7 @@ int CWSFPack::LoadPackV1( wsf_file *PFile, wsul *nIDs, wsul nNumIDs, int nNoBulk
 			wSamp->cSignature[30] = 0;
 
 			// Read Sample Size
-			wsfread(&wSamp->nSize,sizeof(unsigned long),PFile);
+			wsfread(&wSamp->nSize,4,PFile);
 			wSamp->nRawSize = wSamp->nSize;
 			wSamp->nStoredSize = wSamp->nSize;
 
@@ -669,8 +669,8 @@ int CWSFPack::LoadPackV1( wsf_file *PFile, wsul *nIDs, wsul nNumIDs, int nNoBulk
 		else
 		{
 			// Compressed Sampledata ;_;
-			unsigned long nFullSize;	// Full Size
-			unsigned long nCompSize;	// Size when Compressed
+			unsigned int nFullSize;	// Full Size
+			unsigned int nCompSize;	// Size when Compressed
 			wsfb *bCompData;			// Compressed DAta
 
 			// Sample Signature
@@ -678,7 +678,7 @@ int CWSFPack::LoadPackV1( wsf_file *PFile, wsul *nIDs, wsul nNumIDs, int nNoBulk
 			wSamp->cSignature[30] = 0;
 
 			// Sample Size
-			wsfread(&nCompSize,sizeof(unsigned long),PFile);
+			wsfread(&nCompSize,4,PFile);
 			wSamp->nStoredSize = nCompSize;
 
 			if (nF)
@@ -688,7 +688,7 @@ int CWSFPack::LoadPackV1( wsf_file *PFile, wsul *nIDs, wsul nNumIDs, int nNoBulk
 				wsfread(bCompData,nCompSize,PFile);
 
 				// Sample UnComp Size
-				wsfread(&nFullSize,sizeof(unsigned long),PFile);
+				wsfread(&nFullSize,4,PFile);
 				wSamp->nSize = nFullSize;
 				wSamp->nRawSize = nFullSize;
 
@@ -803,7 +803,7 @@ int CWSFPack::LoadPack( wsf_file *PFile, wsul *nIDs, wsul nNumIDs, int nNoBulk, 
 	wsfread(&bComp,1,PFile);	// 
 
 	// Get Number of Samples
-	wsfread(&m_nSamples,sizeof(unsigned long),PFile);
+	wsfread(&m_nSamples,4,PFile);
 
 	// Reallocate for number of samples
 	m_wSamples = (wsf_sample*)realloc(m_wSamples,sizeof(wsf_sample)*m_nSamples);
@@ -837,8 +837,8 @@ int CWSFPack::LoadPack( wsf_file *PFile, wsul *nIDs, wsul nNumIDs, int nNoBulk, 
 
 int CWSFPack::MakeOldSignature( wsfb *wSamp, wsul nSize, char *cOut )
 {
-	unsigned long i=0;
-	unsigned long nSegLen;
+	unsigned int i=0;
+	unsigned int nSegLen;
 	wsfb *bPos;
 	char *cPos;
 
@@ -897,8 +897,8 @@ int CWSFPack::MakeOldSignature( wsfb *wSamp, wsul nSize, char *cOut )
 
 int CWSFPack::CreateSignature( wsfb *wSamp, wsul nSize, wsus nCh, wsus nBit, wsul nSamps, char *cOut )
 {
-	unsigned long nSegLen;		// Size of each segment to scan in order to equal SIGNATURESIZE for cOut
-	unsigned long i;
+	unsigned int nSegLen;		// Size of each segment to scan in order to equal SIGNATURESIZE for cOut
+	unsigned int i;
 	wsfb *bPos;
 	char *cPos;
 	wsul nSub;
@@ -1065,7 +1065,7 @@ int CWSFPack::CreateSignature( wsfb *wSamp, wsul nSize, wsus nCh, wsus nBit, wsu
 // 
 //***************************************************************************** */
 
-int CWSFPack::CompressSample( wsfb *bFullSamp, unsigned long nFullSize, wsfb **bOutSamp, unsigned long *nCompSize )
+int CWSFPack::CompressSample( wsfb *bFullSamp, unsigned int nFullSize, wsfb **bOutSamp, unsigned int *nCompSize )
 {
 	return DoCompression(bFullSamp,nFullSize,0,bOutSamp,nCompSize,true);
 }
@@ -1084,9 +1084,9 @@ int CWSFPack::CompressSample( wsfb *bFullSamp, unsigned long nFullSize, wsfb **b
 // 
 //***************************************************************************** */
 
-unsigned long CWSFPack::SampleExist( char *cSampSig, int nCh, int nBit )
+unsigned int CWSFPack::SampleExist( char *cSampSig, int nCh, int nBit )
 {
-	unsigned long i;
+	unsigned int i;
 
 	// Search!
 	for (i=0;i<m_nSamples;i++)
@@ -1599,7 +1599,7 @@ wsul CWSFPack::SampleExist( wsf_sampout *wInSamp, wsfb *bFlag, wsul *nPar, float
 // 
 //***************************************************************************** */
 
-unsigned long CWSFPack::AddSample( wsf_sampout *wInSamp, wsfb *bSig )
+unsigned int CWSFPack::AddSample( wsf_sampout *wInSamp, wsfb *bSig )
 {
 	wsf_sample *wSamp;
 
@@ -1702,7 +1702,7 @@ int CWSFPack::SavePack( wsfb **bData, wsul *nSize, wsfb bComp )
 int CWSFPack::SavePack( wsf_file *PFile, wsfb bComp )
 {
 	wsfb bHi, bLo;
-	unsigned long i;
+	unsigned int i;
 
 	// Setup Stuff
 	bHi = WSFPVERHI;
@@ -1728,7 +1728,7 @@ int CWSFPack::SavePack( wsf_file *PFile, wsfb bComp )
 	wsfwrite(&bComp,1,PFile);	// (at 1.0 should be 0)
 
 	// # of samples
-	wsfwrite(&m_nSamples,sizeof(unsigned long),PFile);
+	wsfwrite(&m_nSamples,4,PFile);
 
 #if WINWSF
 	g_mStatus->SetSubProgressSteps(m_nSamples);
@@ -1795,7 +1795,7 @@ int CWSFPack::SavePack( wsf_file *PFile, wsfb bComp )
 			wsfwrite(wSamp->cSignature,30,PFile);
 
 			// Write Sample Size
-			wsfwrite(&nSSize,sizeof(unsigned long),PFile);
+			wsfwrite(&nSSize,4,PFile);
 
 			// Encode Sample
 			if (m_nPassSum)
@@ -1811,8 +1811,8 @@ int CWSFPack::SavePack( wsf_file *PFile, wsfb bComp )
 		else
 		{
 			// Compressed Sampledata ;_;
-			unsigned long nFullSize;	// Full Size
-			unsigned long nCompSize;	// Size when Compressed
+			unsigned int nFullSize;	// Full Size
+			unsigned int nCompSize;	// Size when Compressed
 			wsfb *bCompData;			// Compressed Data
 
 			// Sample Signature
@@ -1830,13 +1830,13 @@ int CWSFPack::SavePack( wsf_file *PFile, wsfb bComp )
 				DecodeData(bSData,m_nPassSum,nSSize);
 
 			// Sample Size
-			wsfwrite(&nCompSize,sizeof(unsigned long),PFile);
+			wsfwrite(&nCompSize,4,PFile);
 			
 			// Make memory and compressed sample data
 			wsfwrite(bCompData,nCompSize,PFile);
 
 			// Sample UnComp Size
-			wsfwrite(&nFullSize,sizeof(unsigned long),PFile);
+			wsfwrite(&nFullSize,4,PFile);
 
 			free(bCompData);
 		}
@@ -1879,7 +1879,7 @@ int CWSFPack::SavePack( wsf_file *PFile, wsfb bComp )
 {
 	wsfb bHi, bLo;
 	wsfb bC;
-	unsigned long i;
+	unsigned int i;
 
 	// Setup Stuff
 	bHi = WSFPVERHI;
@@ -1905,7 +1905,7 @@ int CWSFPack::SavePack( wsf_file *PFile, wsfb bComp )
 	wsfwrite(&bComp,1,PFile);	// (at 1.0 should be 0)
 
 	// # of samples
-	wsfwrite(&m_nSamples,sizeof(unsigned long),PFile);
+	wsfwrite(&m_nSamples,4,PFile);
 
 #if WINWSF
 	g_mStatus->SetSubProgressSteps(m_nSamples);
@@ -1996,7 +1996,7 @@ int CWSFPack::SavePack( wsf_file *PFile, wsfb bComp )
 			// Uncompressed sampledata
 
 			// Write Sample Size
-			wsfwrite(&nSSize,sizeof(unsigned long),PFile);
+			wsfwrite(&nSSize,4,PFile);
 
 			// Encode Sample
 			if (m_nPassSum)
@@ -2012,8 +2012,8 @@ int CWSFPack::SavePack( wsf_file *PFile, wsfb bComp )
 		else
 		{
 			// Compressed Sampledata ;_;
-			unsigned long nFullSize;	// Full Size
-			unsigned long nCompSize;	// Size when Compressed
+			unsigned int nFullSize;	// Full Size
+			unsigned int nCompSize;	// Size when Compressed
 			wsfb *bCompData;			// Compressed Data
 
 			// Encode Sample
@@ -2028,13 +2028,13 @@ int CWSFPack::SavePack( wsf_file *PFile, wsfb bComp )
 				DecodeData2(bSData,m_nPassSum,nSSize);
 
 			// Sample Size
-			wsfwrite(&nCompSize,sizeof(unsigned long),PFile);
+			wsfwrite(&nCompSize,4,PFile);
 			
 			// Make memory and compressed sample data
 			wsfwrite(bCompData,nCompSize,PFile);
 
 			// Sample UnComp Size
-			wsfwrite(&nFullSize,sizeof(unsigned long),PFile);
+			wsfwrite(&nFullSize,4,PFile);
 
 			free(bCompData);
 		}
@@ -2078,7 +2078,7 @@ int CWSFPack::SavePack( wsf_file *PFile, wsfb bComp )
 
 int CWSFPack::FreePack( void )
 {
-	unsigned long i;
+	unsigned int i;
 
 	// Only call if loaded
 	if (!m_nLoaded)
@@ -2106,11 +2106,11 @@ int CWSFPack::FreePack( void )
 // [nLow] :
 // [nHi] :
 // 
-// Returns:	unsigned long
+// Returns:	unsigned int
 // 
 //***************************************************************************** */
 
-unsigned long CWSFPack::MakePercent( wsul nLow, wsul nHi )
+unsigned int CWSFPack::MakePercent( wsul nLow, wsul nHi )
 {
 	double n1;
 	double n2;
@@ -2141,7 +2141,7 @@ unsigned long CWSFPack::MakePercent( wsul nLow, wsul nHi )
 
 int CWSFPack::GetSamp( wsf_sampout *wOut, char *cSampSig )
 {
-	unsigned long i;
+	unsigned int i;
 
 	wOut->bSampData = 0;
 	wOut->nSize = 0;
@@ -2183,7 +2183,7 @@ int CWSFPack::GetSamp( wsf_sampout *wOut, char *cSampSig )
 // 
 //***************************************************************************** */
 
-int CWSFPack::GetSampV1( wsf_sampout *wOut, unsigned long nID, wsfb bFlag, wsul nPar, wsfb bAmp )
+int CWSFPack::GetSampV1( wsf_sampout *wOut, unsigned int nID, wsfb bFlag, wsul nPar, wsfb bAmp )
 {
 	wsul nSize;
 	wsfb *bWPos;
@@ -2326,7 +2326,7 @@ int CWSFPack::GetSampV1( wsf_sampout *wOut, unsigned long nID, wsfb bFlag, wsul 
 	return 0;
 }
 
-int CWSFPack::GetSamp( wsf_sampout *wOut, unsigned long nID, wsfb bFlag, wsul nPar, wsfb bAmp )
+int CWSFPack::GetSamp( wsf_sampout *wOut, unsigned int nID, wsfb bFlag, wsul nPar, wsfb bAmp )
 {
 	return GetSampV1(wOut,nID,bFlag,nPar,bAmp);
 }
@@ -2347,7 +2347,7 @@ int CWSFPack::GetSamp( wsf_sampout *wOut, unsigned long nID, wsfb bFlag, wsul nP
 //
 //////////////////////////////////////////////////////
 
-int CWSFPack::GetSampV2( wsf_sampout *wOut, unsigned long nID, wsfb bFlag, wsul nPar, wsul nPar2, float bAmp, WSF2Samps wSamps )
+int CWSFPack::GetSampV2( wsf_sampout *wOut, unsigned int nID, wsfb bFlag, wsul nPar, wsul nPar2, float bAmp, WSF2Samps wSamps )
 {
 	wsul nSize;
 	wsfb *bWPos;

--- a/WSFPack.h
+++ b/WSFPack.h
@@ -94,7 +94,7 @@ typedef struct wsf2samparray_s
 	wsul nSamplesTotal; ///< Total number of samples in the mod (Only used in WINWSF)
 #endif
 	wsul nCurID;	///< ID of the currently tested sample. :0
-	long *nSCounts; ///< Used to count the total number of each type. :D See CWSFLoader::Save()
+	int *nSCounts; ///< Used to count the total number of each type. :D See CWSFLoader::Save()
 
 } WSF2SampArray;
 
@@ -130,15 +130,15 @@ public:
 
 	/// Gets sample by ID. Use with Version 1!
 	/// \return 0 if no error, 1 if error, -1 if loaded sample but NO SAMPLE DATA
-	int GetSampV2( wsf_sampout *wOut, unsigned long nID, wsfb bFlag, wsul nPar1, wsul nPar2 = 0, float bAmp = 100.0f, WSF2Samps wSamps = NULL ); // Returns 1 if error :<
+	int GetSampV2( wsf_sampout *wOut, unsigned int nID, wsfb bFlag, wsul nPar1, wsul nPar2 = 0, float bAmp = 100.0f, WSF2Samps wSamps = NULL ); // Returns 1 if error :<
 
 	/// Gets sample by ID. V1.x WSFMod compatible!
 	/// \return 0 if no error, 1 if error, -1 if loaded sample but NO SAMPLE DATA
-	int GetSampV1( wsf_sampout *wOut, unsigned long nID, wsfb bFlag, wsul nPar, wsfb bAmp ); // Returns 1 if error :<
+	int GetSampV1( wsf_sampout *wOut, unsigned int nID, wsfb bFlag, wsul nPar, wsfb bAmp ); // Returns 1 if error :<
 
 	/// Gets sample by ID, used internally when not loading. Refers to V1.x WSFMod.
 	/// (Usually used when retrieving no data)
-	int GetSamp( wsf_sampout *wOut, unsigned long nID, wsfb bFlag, wsul nPar, wsfb bAmp );
+	int GetSamp( wsf_sampout *wOut, unsigned int nID, wsfb bFlag, wsul nPar, wsfb bAmp );
 
 	/// Gets a samples size, even if its unloaded.
 	wsul GetSampSize( wsul nID );
@@ -193,17 +193,17 @@ public:
 	int SavePack( wsf_file *PFile, wsfb bComp );
 
 	/// Compresses Sample
-	int CompressSample( wsfb *bFullSamp, unsigned long nFullSize, wsfb **bOutSamp, unsigned long *nCompSize );
+	int CompressSample( wsfb *bFullSamp, unsigned int nFullSize, wsfb **bOutSamp, unsigned int *nCompSize );
 
 #endif
 
 	/// DeCompresses Sample
-	int DeCompressSample( wsfb *bCompSamp, unsigned long nCompSize, wsfb **bOutSamp, unsigned long nFullSize );
+	int DeCompressSample( wsfb *bCompSamp, unsigned int nCompSize, wsfb **bOutSamp, unsigned int nFullSize );
 
 	/// Makes percentage out of two integers
 	/// \param nLow Low UL (50 out of 100 = 50)
 	/// \param nHi Hi UL (50 out of 100 = 100)
-	unsigned long MakePercent( wsul nLow, wsul nHi );
+	unsigned int MakePercent( wsul nLow, wsul nHi );
 
 	void SetSampleFreq( wsul nID, wsul nFreq )
 	{
@@ -212,7 +212,7 @@ public:
 	};
 
 	/// Gets Number of Samples
-	unsigned long GetNumSamples( void )
+	unsigned int GetNumSamples( void )
 	{
 		return m_nSamples;
 	};
@@ -256,7 +256,7 @@ private:
 
 	int m_nLoaded;				// Loaded?
 
-	unsigned long m_nSamples;	// Number of Samples
+	unsigned int m_nSamples;	// Number of Samples
 	wsf_sample *m_wSamples;		// Samples	
 
 };

--- a/WSFPackV1.cpp
+++ b/WSFPackV1.cpp
@@ -62,8 +62,8 @@ extern CStatusDlg *g_mStatus;
 
 wsfb	*gp_bS;	// Byte Start
 wsfb	*gp_bP;	// Byte Pos
-unsigned long gp_nB;	// Size of bytes
-unsigned long gp_nW;
+unsigned int gp_nB;	// Size of bytes
+unsigned int gp_nW;
 
 #define POPEN(x,y)		{ gp_bS = x; gp_bP = gp_bS; gp_nB = y; gp_nW = 0; }
 #define PREAD(x,y,z)	{ memcpy(x,gp_bP,y*z); gp_bP+=y*z; }
@@ -77,8 +77,8 @@ unsigned long gp_nW;
 
 wsfb	*gm_bS;	// Byte Start
 wsfb	*gm_bP;	// Byte Pos
-unsigned long gm_nB;	// Size of bytes
-unsigned long gm_nW;
+unsigned int gm_nB;	// Size of bytes
+unsigned int gm_nW;
 
 #define MOPEN(x,y)		{ gm_bS = x; gm_bP = gm_bS; gm_nB = y; gm_nW = 0; }
 #define MREAD(x,y,z)	{ memcpy(x,gm_bP,y*z); gm_bP+=y*z; }
@@ -222,7 +222,7 @@ CWSFPackV1::~CWSFPackV1()
 // 
 //***************************************************************************** */
 
-int CWSFPackV1::CompressSample( wsfb *bFullSamp, unsigned long nFullSize, wsfb **bOutSamp, unsigned long *nCompSize )
+int CWSFPackV1::CompressSample( wsfb *bFullSamp, unsigned int nFullSize, wsfb **bOutSamp, unsigned int *nCompSize )
 {
 	return DoCompression(bFullSamp,nFullSize,0,bOutSamp,nCompSize,true);
 }
@@ -244,7 +244,7 @@ int CWSFPackV1::CompressSample( wsfb *bFullSamp, unsigned long nFullSize, wsfb *
 // 
 //***************************************************************************** */
 
-int CWSFPackV1::DeCompressSample( wsfb *bCompSamp, unsigned long nCompSize, wsfb **bOutSamp, unsigned long nFullSize )
+int CWSFPackV1::DeCompressSample( wsfb *bCompSamp, unsigned int nCompSize, wsfb **bOutSamp, unsigned int nFullSize )
 {
 	return DoCompression(bCompSamp,nCompSize,nFullSize,bOutSamp,NULL,false);
 }
@@ -298,7 +298,7 @@ int CWSFPackV1::LoadPack( wsf_file *PFile, wsul *nIDs, wsus nNumIDs )
 	char cHead[4];
 	wsfb bHi, bLo;
 	wsfb bComp;
-	unsigned long i;
+	unsigned int i;
 
 	wsfbegin(0,PFile);
 
@@ -328,7 +328,7 @@ int CWSFPackV1::LoadPack( wsf_file *PFile, wsul *nIDs, wsus nNumIDs )
 	wsfread(&bComp,1,PFile);	// 
 
 	// Get Number of Samples
-	wsfread(&m_nSamples,sizeof(unsigned long),PFile);
+	wsfread(&m_nSamples,sizeof(unsigned int),PFile);
 
 	// Reallocate for number of samples
 	m_wSamples = (wsf_sample*)realloc(m_wSamples,sizeof(wsf_sample)*m_nSamples);
@@ -385,7 +385,7 @@ int CWSFPackV1::LoadPack( wsf_file *PFile, wsul *nIDs, wsus nNumIDs )
 			wSamp->cSignature[30] = 0;
 
 			// Read Sample Size
-			wsfread(&wSamp->nSize,sizeof(unsigned long),PFile);
+			wsfread(&wSamp->nSize,sizeof(unsigned int),PFile);
 			wSamp->nRawSize = wSamp->nSize;
 			wSamp->nStoredSize = wSamp->nSize;
 
@@ -409,8 +409,8 @@ int CWSFPackV1::LoadPack( wsf_file *PFile, wsul *nIDs, wsus nNumIDs )
 		else
 		{
 			// Compressed Sampledata ;_;
-			unsigned long nFullSize;	// Full Size
-			unsigned long nCompSize;	// Size when Compressed
+			unsigned int nFullSize;	// Full Size
+			unsigned int nCompSize;	// Size when Compressed
 			wsfb *bCompData;			// Compressed DAta
 
 			// Sample Signature
@@ -418,7 +418,7 @@ int CWSFPackV1::LoadPack( wsf_file *PFile, wsul *nIDs, wsus nNumIDs )
 			wSamp->cSignature[30] = 0;
 
 			// Sample Size
-			wsfread(&nCompSize,sizeof(unsigned long),PFile);
+			wsfread(&nCompSize,sizeof(unsigned int),PFile);
 			wSamp->nStoredSize = nCompSize;
 
 			if (nF)
@@ -428,7 +428,7 @@ int CWSFPackV1::LoadPack( wsf_file *PFile, wsul *nIDs, wsus nNumIDs )
 				wsfread(bCompData,nCompSize,PFile);
 
 				// Sample UnComp Size
-				wsfread(&nFullSize,sizeof(unsigned long),PFile);
+				wsfread(&nFullSize,sizeof(unsigned int),PFile);
 				wSamp->nSize = nFullSize;
 				wSamp->nRawSize = nFullSize;
 
@@ -558,7 +558,7 @@ int CWSFPackV1::SavePack( wsfb **bData, wsul *nSize, wsfb bComp )
 int CWSFPackV1::SavePack( wsf_file *PFile, wsfb bComp )
 {
 	wsfb bHi, bLo;
-	unsigned long i;
+	unsigned int i;
 
 	// Setup Stuff
 	bHi = WSFP1VERHI;
@@ -584,7 +584,7 @@ int CWSFPackV1::SavePack( wsf_file *PFile, wsfb bComp )
 	wsfwrite(&bComp,1,PFile);	// (at 1.0 should be 0)
 
 	// # of samples
-	wsfwrite(&m_nSamples,sizeof(unsigned long),PFile);
+	wsfwrite(&m_nSamples,sizeof(unsigned int),PFile);
 
 #if WINWSF
 	g_mStatus->SetSubProgressSteps(m_nSamples);
@@ -651,7 +651,7 @@ int CWSFPackV1::SavePack( wsf_file *PFile, wsfb bComp )
 			wsfwrite(wSamp->cSignature,30,PFile);
 
 			// Write Sample Size
-			wsfwrite(&nSSize,sizeof(unsigned long),PFile);
+			wsfwrite(&nSSize,sizeof(unsigned int),PFile);
 
 			// Encode Sample
 			if (m_nPassSum)
@@ -667,8 +667,8 @@ int CWSFPackV1::SavePack( wsf_file *PFile, wsfb bComp )
 		else
 		{
 			// Compressed Sampledata ;_;
-			unsigned long nFullSize;	// Full Size
-			unsigned long nCompSize;	// Size when Compressed
+			unsigned int nFullSize;	// Full Size
+			unsigned int nCompSize;	// Size when Compressed
 			wsfb *bCompData;			// Compressed Data
 
 			// Sample Signature
@@ -686,13 +686,13 @@ int CWSFPackV1::SavePack( wsf_file *PFile, wsfb bComp )
 				DecodeData(bSData,m_nPassSum,nSSize);
 
 			// Sample Size
-			wsfwrite(&nCompSize,sizeof(unsigned long),PFile);
+			wsfwrite(&nCompSize,sizeof(unsigned int),PFile);
 			
 			// Make memory and compressed sample data
 			wsfwrite(bCompData,nCompSize,PFile);
 
 			// Sample UnComp Size
-			wsfwrite(&nFullSize,sizeof(unsigned long),PFile);
+			wsfwrite(&nFullSize,sizeof(unsigned int),PFile);
 
 			free(bCompData);
 		}
@@ -744,7 +744,7 @@ int CWSFPackV1::SavePack( wsf_file *PFile, wsfb bComp )
 
 int CWSFPackV1::FreePack( void )
 {
-	unsigned long i;
+	unsigned int i;
 
 	// Only call if loaded
 	if (!m_nLoaded)
@@ -772,11 +772,11 @@ int CWSFPackV1::FreePack( void )
 // [nLow] :
 // [nHi] :
 // 
-// Returns:	unsigned long
+// Returns:	unsigned int
 // 
 //***************************************************************************** */
 
-unsigned long CWSFPackV1::MakePercent( wsul nLow, wsul nHi )
+unsigned int CWSFPackV1::MakePercent( wsul nLow, wsul nHi )
 {
 	double n1;
 	double n2;
@@ -809,8 +809,8 @@ unsigned long CWSFPackV1::MakePercent( wsul nLow, wsul nHi )
 
 int CWSFPackV1::MakeOldSignature( wsfb *wSamp, wsul nSize, char *cOut )
 {
-	unsigned long i=0;
-	unsigned long nSegLen;
+	unsigned int i=0;
+	unsigned int nSegLen;
 	wsfb *bPos;
 	char *cPos;
 
@@ -869,8 +869,8 @@ int CWSFPackV1::MakeOldSignature( wsfb *wSamp, wsul nSize, char *cOut )
 
 int CWSFPackV1::CreateSignature( wsfb *wSamp, wsul nSize, wsus nCh, wsus nBit, wsul nSamps, char *cOut )
 {
-	unsigned long nSegLen;		// Size of each segment to scan in order to equal SIGNATURESIZE for cOut
-	unsigned long i;
+	unsigned int nSegLen;		// Size of each segment to scan in order to equal SIGNATURESIZE for cOut
+	unsigned int i;
 	wsfb *bPos;
 	char *cPos;
 	wsul nSub;
@@ -1036,7 +1036,7 @@ int CWSFPackV1::CreateSignature( wsfb *wSamp, wsul nSize, wsus nCh, wsus nBit, w
 
 int CWSFPackV1::GetSamp( wsf_sampout *wOut, char *cSampSig )
 {
-	unsigned long i;
+	unsigned int i;
 
 	// Search!
 	for (i=0;i<m_nSamples;i++)
@@ -1076,7 +1076,7 @@ int CWSFPackV1::GetSamp( wsf_sampout *wOut, char *cSampSig )
 // 
 //***************************************************************************** */
 
-int CWSFPackV1::GetSamp( wsf_sampout *wOut, unsigned long nID, wsfb bFlag, wsul nPar, wsfb bAmp )
+int CWSFPackV1::GetSamp( wsf_sampout *wOut, unsigned int nID, wsfb bFlag, wsul nPar, wsfb bAmp )
 {
 	wsul nSize;
 	wsfb *bWPos;
@@ -1219,9 +1219,9 @@ int CWSFPackV1::GetSamp( wsf_sampout *wOut, unsigned long nID, wsfb bFlag, wsul 
 // 
 //***************************************************************************** */
 
-unsigned long CWSFPackV1::SampleExist( char *cSampSig, int nCh, int nBit )
+unsigned int CWSFPackV1::SampleExist( char *cSampSig, int nCh, int nBit )
 {
-	unsigned long i;
+	unsigned int i;
 
 	// Search!
 	for (i=0;i<m_nSamples;i++)
@@ -1579,7 +1579,7 @@ wsul CWSFPackV1::SampleExist( wsf_sampout *wInSamp, wsfb *bFlag, wsul *nPar, wsf
 // 
 //***************************************************************************** */
 
-unsigned long CWSFPackV1::AddSample( wsf_sampout *wInSamp, wsfb *bSig )
+unsigned int CWSFPackV1::AddSample( wsf_sampout *wInSamp, wsfb *bSig )
 {
 	wsf_sample *wSamp;
 

--- a/WSFPackV1.h
+++ b/WSFPackV1.h
@@ -72,7 +72,7 @@ public:
 	int GetSamp( wsf_sampout *wOut, char *cSampSig );	// Returns 1 if error :<
 
 	/// Gets sample by ID
-	int GetSamp( wsf_sampout *wOut, unsigned long nID, wsfb bFlag, wsul nPar, wsfb bAmp ); // Returns 1 if error :<
+	int GetSamp( wsf_sampout *wOut, unsigned int nID, wsfb bFlag, wsul nPar, wsfb bAmp ); // Returns 1 if error :<
 
 	/// Gets a samples size, even if its unloaded.
 	wsul GetSampSize( wsul nID );
@@ -123,17 +123,17 @@ public:
 	int SavePack( wsf_file *PFile, wsfb bComp );
 
 	/// DeCompresses Sample
-	int DeCompressSample( wsfb *bCompSamp, unsigned long nCompSize, wsfb **bOutSamp, unsigned long nFullSize );
+	int DeCompressSample( wsfb *bCompSamp, unsigned int nCompSize, wsfb **bOutSamp, unsigned int nFullSize );
 	/// Compresses Sample
-	int CompressSample( wsfb *bFullSamp, unsigned long nFullSize, wsfb **bOutSamp, unsigned long *nCompSize );
+	int CompressSample( wsfb *bFullSamp, unsigned int nFullSize, wsfb **bOutSamp, unsigned int *nCompSize );
 
 	/// Makes percentage out of two integers
 	/// \param nLow Low UL (50 out of 100 = 50)
 	/// \param nHi Hi UL (50 out of 100 = 100)
-	unsigned long MakePercent( wsul nLow, wsul nHi );
+	unsigned int MakePercent( wsul nLow, wsul nHi );
 
 	/// Gets Number of Samples
-	unsigned long GetNumSamples( void )
+	unsigned int GetNumSamples( void )
 	{
 		return m_nSamples;
 	};
@@ -168,7 +168,7 @@ private:
 
 	int m_nLoaded;				// Loaded?
 
-	unsigned long m_nSamples;	// Number of Samples
+	unsigned int m_nSamples;	// Number of Samples
 	wsf_sample *m_wSamples;		// Samples	
 
 };

--- a/WSFSpecialTags.cpp
+++ b/WSFSpecialTags.cpp
@@ -52,12 +52,12 @@ char b[11][10] =
 
 #pragma warning(disable: 4244)
 
-void CWSFSTagHandler::RunSEcho( int *bSmpPtr, long nSamples, int nCh, int nBitRate )
+void CWSFSTagHandler::RunSEcho( int *bSmpPtr, int nSamples, int nCh, int nBitRate )
 {
 	int x,s,e;
 	int idx;
-	long ctr;
-	long delay;
+	int ctr;
+	int delay;
 	delay = 50;
 	int *buf;
 	int len;
@@ -269,7 +269,7 @@ void CWSFSTagHandler::InitDSPEffects( int nBitRate, int nCh, int nSRate )
 //
 //////////////////////////////////////////////////////
 
-void CWSFSTagHandler::ProcessDSPEffects( int **bSmpPtr, long nSamples, int nCh, int nBitRate, int nSRate )
+void CWSFSTagHandler::ProcessDSPEffects( int **bSmpPtr, int nSamples, int nCh, int nBitRate, int nSRate )
 {
 	if (nBitRate != 32 || bSmpPtr == NULL)
 		return;
@@ -278,7 +278,7 @@ void CWSFSTagHandler::ProcessDSPEffects( int **bSmpPtr, long nSamples, int nCh, 
 	{
 		int p,m,l;
 		int x;
-		long s;
+		int s;
 		p = m = l = 0;
 
 		for (p=0;p<nSamples;p++)
@@ -298,7 +298,7 @@ void CWSFSTagHandler::ProcessDSPEffects( int **bSmpPtr, long nSamples, int nCh, 
         for (x = 0; x < nSamples; x++)
         {
 			for (m=0;m<nCh;m++){
-				long y;
+				int y;
 				y = m_interw[p];
 				if (y> 0x7FFFFF)
 					y=0x7FFFFF;
@@ -399,10 +399,10 @@ wsf_stags *CWSFSTagHandler::GetSettings( void )
 
 #if 0
 	
-void DoReverb(unsigned char *buf,long len)
+void DoReverb(unsigned char *buf,int len)
 {
 short int x,s,e;
-long ctr;
+int ctr;
 
    for(ctr=0; ctr<len; ctr+=2)
    {

--- a/WSFSpecialTags.h
+++ b/WSFSpecialTags.h
@@ -77,11 +77,11 @@ public:
 	void InitDSPEffects( int nBitRate, int nCh, int nSRate );
 
 	// Process DSP Effects
-	void ProcessDSPEffects( int **bSmpPtr, long nSamples,
+	void ProcessDSPEffects( int **bSmpPtr, int nSamples,
 		int nCh, int nBitRate, int nSRate );
 
 	// Simple Echo Processer
-	void RunSEcho( int *bSmpPtr, long nSamples,
+	void RunSEcho( int *bSmpPtr, int nSamples,
 		int nCh, int nBitRate );
 
 	void Reset( void );

--- a/WSFTool.cpp
+++ b/WSFTool.cpp
@@ -182,7 +182,7 @@ void RunTOWSF( WSFTSets *wS )
 	char **cVals;
 	char **cTags;
 	int nTags;
-	long nSCount[WSFS_COUNT];
+	int nSCount[WSFS_COUNT];
 	wsf_modout wO;
 	FILE *OFile;
 	CWSFAscii mA;
@@ -216,7 +216,7 @@ void RunTOWSF( WSFTSets *wS )
 	// Search Files
 	if (wS->nInputs > 0)
 	{
-		long nTemp[WSFS_COUNT];
+		int nTemp[WSFS_COUNT];
 		int xc;		
 
 		for (xc=0;xc<WSFS_COUNT;xc++)
@@ -276,7 +276,7 @@ void RunTOWSF( WSFTSets *wS )
 
 		// Get WSF
 		printf("Writing WSF %s...\n",cFile);
-		if (g_wMod->WriteMod(&wO,1,(long*)&nTemp)) {
+		if (g_wMod->WriteMod(&wO,1,(int*)&nTemp)) {
 			printf("Could not write %s\n",cFile);
 			return;
 		}
@@ -357,7 +357,7 @@ void RunTOWSF( WSFTSets *wS )
 
 			// Get WSF
 			printf("Writing WSF %s...\n",cFile);
-			if (g_wMod->WriteMod(&wO,1,(long*)&nTemp)) {
+			if (g_wMod->WriteMod(&wO,1,(int*)&nTemp)) {
 				printf("Could not write %s\n",cFile);
 				return;
 			}
@@ -682,7 +682,7 @@ void FillSetting( char *cLine, int nNum, WSFTSets *wS )
 	if (cmd[0] != '-' && cmd[0] != '/') {
 #ifdef WIN32
 		FINDDATA c_file;
-		long hFile=0;
+		int hFile=0;
 		
 		if ((hFile = FINDFIRST(cmd,&c_file)) != FINDERR)
 		{
@@ -1188,7 +1188,7 @@ wsul GetModLength( char *cIn )
 	return nSecs;
 }
 
-void mp3sDSPProc(void *data, sample_t **samples, int n_channels, long length)
+void mp3sDSPProc(void *data, sample_t **samples, int n_channels, int length)
 {
 	CWSFSTagHandler *gST;
 	gST = (CWSFSTagHandler*)data;
@@ -1230,7 +1230,7 @@ void WriteMp3( WSFTSets *wS, char *cIn, char *cFile )
 	int done=0;
 	int nCount=0;
 	float delta;
-	long towrite=576*2*2;
+	int towrite=576*2*2;
 	DUH_SIGRENDERER *dSig;
 	wsul nLen;
 	DUMB_IT_SIGRENDERER *itsr;

--- a/WSFTool.h
+++ b/WSFTool.h
@@ -62,7 +62,7 @@ typedef struct wsft_s
 	/// Number Arg
 	/// MP3:
 	/// 0 - bitrate, 1 - quality
-	long nArg[20];
+	int nArg[20];
 
 	/// Number of Tags
 	int nTags;

--- a/lzoconf.h
+++ b/lzoconf.h
@@ -98,8 +98,8 @@ extern "C" {
      typedef int                lzo_int32;
 #    define LZO_UINT32_MAX      UINT_MAX
 #  elif (ULONG_MAX >= 0xffffffffL)
-     typedef unsigned long      lzo_uint32;
-     typedef long               lzo_int32;
+     typedef unsigned int      lzo_uint32;
+     typedef int               lzo_int32;
 #    define LZO_UINT32_MAX      ULONG_MAX
 #  else
 #    error lzo_uint32
@@ -113,8 +113,8 @@ extern "C" {
      typedef int                lzo_int;
 #    define LZO_UINT_MAX        UINT_MAX
 #  elif (ULONG_MAX >= 0xffffffffL)
-     typedef unsigned long      lzo_uint;
-     typedef long               lzo_int;
+     typedef unsigned int      lzo_uint;
+     typedef int               lzo_int;
 #    define LZO_UINT_MAX        ULONG_MAX
 #  else
 #    error lzo_uint


### PR DESCRIPTION
The 'long' type is usually 64-bit long on 64-bit processors, so reading 'long's in binary files lead to invalid readings.
I had to turn most 'long' types into 'int' so it works correctly.
